### PR TITLE
Added base code for using multiple mirrors

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -3,3 +3,4 @@ N_AUTHORS = 1 # Maximum of authors displayed.
 MAX_CHARS_AUTHORS = 25 # Maximum characters displayed for the author. Change according to N_AUTHORS.
 MAX_CHARS_TITLE = 50 # Maximum characters displayed for the book title
 MAX_CHARS_PUBLISHER = 20 # Maximum characters displayed for the publisher.
+MULTIPLE_MIRRORS = False # Multiple Mirrors to download


### PR DESCRIPTION
Reference - Issue #1 
On bookfi four mirrors are provided, we are already using the first mirror as default download mirror.
I tried to implement download through the rest of the three mirrors, however the following problem arose -

Mirror 1 (Default Mirror/Currently in use) - Working Completely fine.
Mirror 2 - Blocking crawlers, my IP is banned for 24 hrs.
![screen shot 2017-10-21 at 11 54 42 am](https://user-images.githubusercontent.com/14851333/31850457-8dd80c06-b66f-11e7-8b7d-6089f13e951d.png)
Mirror 3 - Unable to get a direct download url as they are using MD5 hash to store the books.
Mirror 4 - Unable to get a direct download url as they are using MD5 hash to store the books.

Although, I have implemented the base code for using multiple mirrors, this way integrating mirrors in future will be easy.

